### PR TITLE
add undocumented gravity to example

### DIFF
--- a/examples/imager.js
+++ b/examples/imager.js
@@ -13,7 +13,7 @@ module.exports = {
       resizeAndCrop: {
         large: {
           resize: '1000x1000',
-          crop: '900x900'
+          crop: '900x900 Center'
         }
       }
     },


### PR DESCRIPTION
It is not documented, that you can specify the gravity when cropping images. So I thought it would be nice, if it is at least in the example